### PR TITLE
Refactor for CLI video rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ Companion application for your Counter-Strike demos.
 ## License
 
 [MIT](https://github.com/akiver/cs-demo-manager/blob/main/LICENSE)
+
+## CLI usage
+
+This refactored version focuses on a command line tool that only generates videos.
+
+Run the `video` command with a path to a JSON configuration:
+
+```sh
+npm run dev:cli -- video example-video.json
+```
+
+An example configuration file is available at `example-video.json`.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,2 @@
 services:
-  db:
-    image: postgres:17
-    restart: always
-    container_name: csdm-postgresql
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB:-csdm_dev}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
-    ports:
-      - '${POSTGRES_PORT:-5432}:5432'
+  # No database container needed. SQLite database file will be created locally.

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose -f docker-compose.yml -p csdm up -d
+echo "No services to start"

--- a/docker/stop.sh
+++ b/docker/stop.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker compose -f docker-compose.yml stop
+echo "No services to stop"

--- a/example-video.json
+++ b/example-video.json
@@ -1,0 +1,38 @@
+{
+  "checksum": "1234567890abcdef",
+  "demoPath": "path/to/demo.dem",
+  "mapName": "de_inferno",
+  "game": "CSGO",
+  "tickrate": 64,
+  "recordingSystem": "CounterStrike",
+  "recordingOutput": "Video",
+  "encoderSoftware": "FFmpeg",
+  "framerate": 30,
+  "width": 1280,
+  "height": 720,
+  "closeGameAfterRecording": true,
+  "concatenateSequences": false,
+  "ffmpegSettings": {
+    "audioBitrate": 256,
+    "constantRateFactor": 23,
+    "videoContainer": "AVI",
+    "videoCodec": "libx264",
+    "audioCodec": "libmp3lame",
+    "inputParameters": "",
+    "outputParameters": ""
+  },
+  "outputFolderPath": "output",
+  "sequences": [
+    {
+      "number": 1,
+      "startTick": 0,
+      "endTick": 10000,
+      "showXRay": true,
+      "showOnlyDeathNotices": true,
+      "playersOptions": [],
+      "cameras": [],
+      "playerVoicesEnabled": true,
+      "deathNoticesDuration": 5
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "motion": "12.15.0",
     "navigation-api-types": "0.6.1",
     "node-stream-zip": "1.15.0",
-    "pg": "8.16.0",
+    "better-sqlite3": "8.6.0",
     "prettier": "3.5.3",
     "react": "19.1.0",
     "react-day-picker": "9.7.0",

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -4,6 +4,7 @@ import { DownloadFaceitCommand } from './commands/download-faceit-command';
 import { HelpCommand } from './commands/help-command';
 import { XlsxCommand } from './commands/xlsx-command';
 import { JsonCommand } from './commands/json-command';
+import { VideoCommand } from './commands/video-command';
 
 export const commands = {
   [AnalyzeCommand.Name]: AnalyzeCommand,
@@ -12,4 +13,5 @@ export const commands = {
   [HelpCommand.Name]: HelpCommand,
   [JsonCommand.Name]: JsonCommand,
   [XlsxCommand.Name]: XlsxCommand,
+  [VideoCommand.Name]: VideoCommand,
 };

--- a/src/cli/commands/video-command.ts
+++ b/src/cli/commands/video-command.ts
@@ -1,0 +1,61 @@
+import fs from 'fs-extra';
+import { v4 as uuidv4 } from 'uuid';
+import { Command } from './command';
+import { generateVideo } from 'csdm/node/video/generation/generate-video';
+import { assertVideoGenerationIsPossible } from 'csdm/node/video/generation/assert-video-generation-is-possible';
+import { isFfmpegInstalled } from 'csdm/node/video/ffmpeg/is-ffmpeg-installed';
+import { installFfmpeg } from 'csdm/node/video/ffmpeg/install-ffmpeg';
+import { isHlaeInstalled } from 'csdm/node/video/hlae/is-hlae-installed';
+import { downloadHlae } from 'csdm/node/video/hlae/download-hlae';
+import { getDefaultHlaeInstallationFolderPath } from 'csdm/node/video/hlae/hlae-location';
+import type { AddVideoPayload } from 'csdm/common/types/video';
+
+export class VideoCommand extends Command {
+  public static Name = 'video';
+
+  public getDescription() {
+    return 'Generate video from demo using a configuration JSON file';
+  }
+
+  public printHelp() {
+    console.log('Usage: csdm video <config.json>');
+  }
+
+  public async run() {
+    await this.parseArgs();
+    const jsonPath = this.args[0];
+    if (!jsonPath) {
+      this.printHelp();
+      this.exitWithFailure();
+    }
+
+    const config: AddVideoPayload = await fs.readJson(jsonPath);
+    await this.ensureDependencies(config);
+
+    await generateVideo({
+      ...config,
+      videoId: uuidv4(),
+      signal: new AbortController().signal,
+      onGameStart: () => console.log('Game started'),
+      onMoveFilesStart: () => console.log('Moving files'),
+      onSequenceStart: (n) => console.log(`Processing sequence ${n}`),
+      onConcatenateSequencesStart: () => console.log('Concatenating sequences'),
+    });
+  }
+
+  private async ensureDependencies(config: AddVideoPayload) {
+    try {
+      await assertVideoGenerationIsPossible(config);
+    } catch (error) {
+      if (!(await isFfmpegInstalled())) {
+        console.log('FFmpeg not installed, installing...');
+        await installFfmpeg();
+      }
+      if (config.recordingSystem === 'HLAE' && !(await isHlaeInstalled())) {
+        console.log('HLAE not installed, downloading...');
+        await downloadHlae(getDefaultHlaeInstallationFolderPath());
+      }
+      await assertVideoGenerationIsPossible(config);
+    }
+  }
+}

--- a/src/node/database/database.ts
+++ b/src/node/database/database.ts
@@ -1,42 +1,14 @@
-import { types, Pool } from 'pg';
+import Database from 'better-sqlite3';
 import type { KyselyConfig, LogEvent, Logger } from 'kysely';
-import { Kysely, PostgresDialect } from 'kysely';
+import { Kysely, SqliteDialect } from 'kysely';
 import type { DatabaseSettings } from 'csdm/node/settings/settings';
 import type { Database } from './schema';
 
 export let db: Kysely<Database>;
 
-// Convert int8 values that are "safe" JS integers into Numbers otherwise leave them as strings.
-// Postgres returns int8 values for int8 columns but also aggregate functions (COUNT(), SUM()...).
-// By default node-pg parses int8 values into strings.
-// We do this conversion for the following reasons:
-// - The only int8 columns in the app are used for tables PK ID and we don't do Math operations on them.
-// - To not have to think about casting values into numbers when using aggregate functions, i.e.:
-//   db.count('id') vs db.raw('COUNT(id)::INT')
-// - Sending BigInts through WebSocket result in strings.
-types.setTypeParser(types.builtins.INT8, (value) => {
-  const valueAsNumber = Number(value);
-  if (Number.isSafeInteger(valueAsNumber)) {
-    return valueAsNumber;
-  }
-
-  return value;
-});
-// Cast numeric types into JS Number so SUM, AVG... will be numbers instead of strings.
-types.setTypeParser(types.builtins.NUMERIC, Number);
-types.setTypeParser(types.builtins.INT4, Number);
-types.setTypeParser(types.builtins.INT2, Number);
-
 export function createDatabaseConnection(settings: DatabaseSettings) {
-  const dialect = new PostgresDialect({
-    pool: new Pool({
-      host: settings.hostname,
-      port: settings.port,
-      user: settings.username,
-      password: settings.password,
-      database: settings.database,
-      connectionTimeoutMillis: 3000,
-    }),
+  const dialect = new SqliteDialect({
+    database: new Database(settings.database),
   });
 
   let loggerFunction: Logger;

--- a/src/node/settings/default-settings.ts
+++ b/src/node/settings/default-settings.ts
@@ -12,11 +12,11 @@ export const defaultSettings: Settings = {
   schemaVersion: CURRENT_SCHEMA_VERSION,
   autoDownloadUpdates: true,
   database: {
-    hostname: '127.0.0.1',
-    port: 5432,
-    username: 'postgres',
-    password: 'password',
-    database: 'csdm',
+    hostname: '',
+    port: 0,
+    username: '',
+    password: '',
+    database: 'csdm.sqlite',
   },
   folders: [],
   demos: {

--- a/src/node/settings/settings.ts
+++ b/src/node/settings/settings.ts
@@ -17,11 +17,11 @@ export type Folder = {
 };
 
 export type DatabaseSettings = {
-  readonly hostname: string;
-  readonly port: number;
-  readonly username: string;
-  readonly password: string;
   readonly database: string;
+  readonly hostname?: string;
+  readonly port?: number;
+  readonly username?: string;
+  readonly password?: string;
 };
 
 type DemosSettings = DemosTableFilter & {


### PR DESCRIPTION
## Summary
- switch database to SQLite
- add `video` command for CLI usage
- update default settings
- drop docker postgres setup
- document new CLI usage with example configuration

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686020176500833185bbe087e4b466d2