### PR TITLE
Add CLI video rendering command

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -4,6 +4,7 @@ import { DownloadFaceitCommand } from './commands/download-faceit-command';
 import { HelpCommand } from './commands/help-command';
 import { XlsxCommand } from './commands/xlsx-command';
 import { JsonCommand } from './commands/json-command';
+import { VideoCommand } from './commands/video-command';
 
 export const commands = {
   [AnalyzeCommand.Name]: AnalyzeCommand,
@@ -11,5 +12,6 @@ export const commands = {
   [DownloadValveCommand.Name]: DownloadValveCommand,
   [HelpCommand.Name]: HelpCommand,
   [JsonCommand.Name]: JsonCommand,
+  [VideoCommand.Name]: VideoCommand,
   [XlsxCommand.Name]: XlsxCommand,
 };

--- a/src/cli/commands/video-command.ts
+++ b/src/cli/commands/video-command.ts
@@ -1,0 +1,82 @@
+import fs from 'fs-extra';
+import { glob } from 'csdm/node/filesystem/glob';
+import { Command } from './command';
+import { generateDemoVideo } from 'csdm/node/video/generate-demo-video';
+
+export class VideoCommand extends Command {
+  public static Name = 'video';
+  private demoPaths: string[] = [];
+  private outputFolderPath: string | undefined;
+  private readonly outputFlag = '--output-folder';
+
+  public getDescription() {
+    return 'Create videos from demo files.';
+  }
+
+  public printHelp() {
+    console.log(this.getDescription());
+    console.log('');
+    console.log(`Usage: csdm ${VideoCommand.Name} demoPaths... ${this.formatFlagForHelp(this.outputFlag)}`);
+    console.log('');
+    console.log('Demos path can be either .dem files or a directory containing demos.');
+    console.log(`The ${this.outputFlag} flag sets the directory where videos will be saved.`);
+  }
+
+  public async run() {
+    await this.parseArgs();
+    if (this.demoPaths.length === 0) {
+      console.log('No demos found');
+      this.exitWithFailure();
+    }
+
+    for (const demoPath of this.demoPaths) {
+      console.log(`Creating video from ${demoPath}`);
+      await generateDemoVideo({ demoPath, outputFolderPath: this.outputFolderPath });
+    }
+  }
+
+  protected async parseArgs() {
+    super.parseArgs(this.args);
+    if (this.args.length === 0) {
+      console.log('No demo path provided');
+      this.printHelp();
+      this.exitWithFailure();
+    }
+
+    for (let index = 0; index < this.args.length; index++) {
+      const arg = this.args[index];
+      if (this.isFlagArgument(arg)) {
+        switch (arg) {
+          case this.outputFlag:
+            if (this.args.length > index + 1) {
+              index += 1;
+              this.outputFolderPath = this.args[index];
+            } else {
+              console.log(`Missing ${this.outputFlag} value`);
+              this.exitWithFailure();
+            }
+            break;
+          default:
+            console.log(`Unknown flag: ${arg}`);
+            this.exitWithFailure();
+        }
+      } else {
+        try {
+          const stats = await fs.stat(arg);
+          if (stats.isDirectory()) {
+            const files = await glob('*.dem', { cwd: arg, absolute: true });
+            this.demoPaths.push(...files);
+          } else if (stats.isFile() && arg.endsWith('.dem')) {
+            this.demoPaths.push(arg);
+          } else {
+            console.log(`Invalid path: ${arg}`);
+            this.exitWithFailure();
+          }
+        } catch {
+          console.log(`Invalid path: ${arg}`);
+          this.exitWithFailure();
+        }
+      }
+    }
+  }
+}

--- a/src/node/video/generate-demo-video.ts
+++ b/src/node/video/generate-demo-video.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from 'node:crypto';
+import { getDemoFromFilePath } from 'csdm/node/demo/get-demo-from-file-path';
+import { getSettings } from 'csdm/node/settings/get-settings';
+import { getOutputFolderPath } from 'csdm/node/video/get-output-folder-path';
+import { generateVideo } from 'csdm/node/video/generation/generate-video';
+import { isHlaeInstalled } from 'csdm/node/video/hlae/is-hlae-installed';
+import { downloadHlae } from 'csdm/node/video/hlae/download-hlae';
+import { getDefaultHlaeInstallationFolderPath } from 'csdm/node/video/hlae/hlae-location';
+import { isFfmpegInstalled } from 'csdm/node/video/ffmpeg/is-ffmpeg-installed';
+import { installFfmpeg } from 'csdm/node/video/ffmpeg/install-ffmpeg';
+import type { Sequence } from 'csdm/common/types/sequence';
+
+export type GenerateDemoVideoOptions = {
+  demoPath: string;
+  outputFolderPath?: string;
+};
+
+export async function generateDemoVideo({ demoPath, outputFolderPath }: GenerateDemoVideoOptions) {
+  const demo = await getDemoFromFilePath(demoPath);
+  const settings = await getSettings();
+  const videoSettings = settings.video;
+
+  const outputPath = outputFolderPath ?? (await getOutputFolderPath(videoSettings, demoPath));
+
+  if (videoSettings.recordingSystem === 'HLAE' && !(await isHlaeInstalled())) {
+    const folderPath = getDefaultHlaeInstallationFolderPath();
+    await downloadHlae(folderPath);
+  }
+
+  if (videoSettings.encoderSoftware === 'FFmpeg' && !(await isFfmpegInstalled())) {
+    await installFfmpeg();
+  }
+
+  const sequence: Sequence = {
+    number: 1,
+    startTick: 1,
+    endTick: demo.tickCount,
+    showXRay: videoSettings.showXRay,
+    showOnlyDeathNotices: videoSettings.showOnlyDeathNotices,
+    playersOptions: [],
+    cameras: [],
+    playerVoicesEnabled: videoSettings.playerVoicesEnabled,
+    deathNoticesDuration: videoSettings.deathNoticesDuration,
+  };
+
+  await generateVideo({
+    videoId: randomUUID(),
+    checksum: demo.checksum,
+    game: demo.game,
+    tickrate: demo.tickrate,
+    recordingSystem: videoSettings.recordingSystem,
+    recordingOutput: videoSettings.recordingOutput,
+    encoderSoftware: videoSettings.encoderSoftware,
+    framerate: videoSettings.framerate,
+    width: videoSettings.width,
+    height: videoSettings.height,
+    closeGameAfterRecording: videoSettings.closeGameAfterRecording,
+    concatenateSequences: false,
+    ffmpegSettings: videoSettings.ffmpegSettings,
+    outputFolderPath: outputPath,
+    demoPath,
+    sequences: [sequence],
+    signal: new AbortController().signal,
+    onGameStart: () => console.log('Game started'),
+    onMoveFilesStart: () => console.log('Moving files'),
+    onSequenceStart: (num) => console.log(`Encoding sequence ${num}`),
+    onConcatenateSequencesStart: () => console.log('Concatenating sequences'),
+  });
+}


### PR DESCRIPTION
## Summary
- provide CLI command to generate videos from demos
- implement `generateDemoVideo` orchestrator

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run compile` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686054ea5cc48331baa2b99ebf3039c7